### PR TITLE
[#LIEF-11411] Fix logger initialization in Loggery

### DIFF
--- a/lib/loggery/gem/version.rb
+++ b/lib/loggery/gem/version.rb
@@ -2,6 +2,6 @@
 
 module Loggery
   module Gem
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/lib/loggery/railtie.rb
+++ b/lib/loggery/railtie.rb
@@ -46,7 +46,7 @@ module Loggery
     config.loggery.enabled = true
     config.loggery.log_file = "log/logstash-#{Rails.env}.log"
 
-    initializer :loggery, before: :initialize_logger do |app|
+    initializer :loggery, before: :logstash_logger do |app|
       LoggerySetup.setup(app) if app.config.loggery.enabled
     end
   end


### PR DESCRIPTION
loggery initializer has to run before logstash initializer.
Previously they were both attached before "initialize_logger" so the
order of "require" statements mattered. I messed it up accidentally
in 213b5020f6618bd7712aafce69695fde15973ad4.
Instead of relying on the order of "require" statements we explictly
attach loggery initializer before logstash initializer.